### PR TITLE
プロトタイプ投稿機能の作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
@@ -3,11 +3,16 @@ package in.tech_camp.protospace_a.controller;
 import java.util.List;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import in.tech_camp.protospace_a.entity.PrototypeEntity;
+import in.tech_camp.protospace_a.form.PrototypeForm;
 import in.tech_camp.protospace_a.repository.PrototypeRepository;
 import lombok.AllArgsConstructor;
+
 
 @Controller
 @AllArgsConstructor
@@ -15,10 +20,44 @@ public class PrototypeController {
 
   private final PrototypeRepository prototypeRepository;
 
-  @GetMapping("/")
-  String showAllPrototypes() {
+  // testディレクトリ内は挙動確認を行っています。
+  @GetMapping("/test")
+  public String showAllPrototypes(Model model) {
     List<PrototypeEntity> prototypes =  prototypeRepository.getAllPrototypes();
     System.out.println("prototypes:" + prototypes);
+
+    // createPrototypeの挙動を確認するため
+    PrototypeForm newPrototypeForm = new PrototypeForm();
+    model.addAttribute("prototypeForm", newPrototypeForm);
     return "tmp/test";
   }
+
+  @PostMapping("/test")
+  public String createPrototype(@ModelAttribute("prototypeForm") PrototypeForm prototypeForm, Model model) {
+    // todo ログイン機能作成後
+    // - ログイン状態の場合のみ、投稿ページへ遷移できること。
+    // - ログアウト状態で投稿ページに遷移しようとすると、ログインページに遷移すること
+
+    // todo プロトタイプの投稿画面作成後
+    // - 投稿に必要な情報が入力されていない場合は、投稿できずにそのページに留まること。
+    // - バリデーションによって投稿ができず、そのページに留まった場合でも、入力済みの項目（画像以外）は消えないこと
+
+    PrototypeEntity prototype = new PrototypeEntity();
+    prototype.setName(prototype.getName());
+    prototype.setConcept(prototype.getConcept());
+    prototype.setCatchphrase(prototype.getCatchphrase());
+    prototype.setImages(prototype.getImages());
+
+    try {
+      prototypeRepository.insertPrototype(prototype);
+    } catch (Exception e) {
+      System.err.println("Error：" + e);
+      return "tmp/test";
+    }
+
+    // todo トップページ作成後
+    // - 正しく投稿できた場合は、トップページへ遷移すること。
+    return "tmp/test";
+  }
+  
 }

--- a/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
@@ -1,0 +1,24 @@
+package in.tech_camp.protospace_a.controller;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import in.tech_camp.protospace_a.entity.PrototypeEntity;
+import in.tech_camp.protospace_a.repository.PrototypeRepository;
+import lombok.AllArgsConstructor;
+
+@Controller
+@AllArgsConstructor
+public class PrototypeController {
+
+  private final PrototypeRepository prototypeRepository;
+
+  @GetMapping("/")
+  String showAllPrototypes() {
+    List<PrototypeEntity> prototypes =  prototypeRepository.getAllPrototypes();
+    System.out.println("prototypes:" + prototypes);
+    return "tmp/test";
+  }
+}

--- a/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
@@ -1,9 +1,12 @@
 package in.tech_camp.protospace_a.controller;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,10 +36,17 @@ public class PrototypeController {
   }
 
   @PostMapping("/test")
-  public String createPrototype(@ModelAttribute("prototypeForm") PrototypeForm prototypeForm, Model model) {
+  public String createPrototype(@ModelAttribute("prototypeForm") @Validated PrototypeForm prototypeForm, BindingResult bindingResult, Model model) {
     // todo ログイン機能作成後
     // - ログイン状態の場合のみ、投稿ページへ遷移できること。
     // - ログアウト状態で投稿ページに遷移しようとすると、ログインページに遷移すること
+    if (bindingResult.hasErrors()) {
+        model.addAttribute("errors", bindingResult.getAllErrors()
+            .stream()
+            .map(error -> error.getDefaultMessage())
+            .collect(Collectors.toList()));
+        return "tmp/test"; // エラーがある場合は元の画面へ戻る
+    }
 
     // todo プロトタイプの投稿画面作成後
     // - 投稿に必要な情報が入力されていない場合は、投稿できずにそのページに留まること。
@@ -59,5 +69,4 @@ public class PrototypeController {
     // - 正しく投稿できた場合は、トップページへ遷移すること。
     return "tmp/test";
   }
-  
 }

--- a/src/main/java/in/tech_camp/protospace_a/entity/PrototypeEntity.java
+++ b/src/main/java/in/tech_camp/protospace_a/entity/PrototypeEntity.java
@@ -1,0 +1,17 @@
+package in.tech_camp.protospace_a.entity;
+
+import java.security.Timestamp;
+
+import lombok.Data;
+
+@Data
+public class PrototypeEntity {
+  private Integer id;
+  private String name;
+  private String catchphrase;
+  private String concept;
+  private String images;
+  private Timestamp createdAt;
+  private Timestamp updatedAt;
+  // private UserEntity user;
+}

--- a/src/main/java/in/tech_camp/protospace_a/form/PrototypeForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/PrototypeForm.java
@@ -1,0 +1,11 @@
+package in.tech_camp.protospace_a.form;
+
+import lombok.Data;
+
+@Data
+public class PrototypeForm {
+  private String name;
+  private String catchphrase;
+  private String concept;
+  private String image;
+}

--- a/src/main/java/in/tech_camp/protospace_a/form/PrototypeForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/PrototypeForm.java
@@ -1,11 +1,16 @@
 package in.tech_camp.protospace_a.form;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class PrototypeForm {
+  @NotBlank(message="Error: Prototype.name can't blank")
   private String name;
+  @NotBlank(message="Error: Prototype.catchphrase can't blank")
   private String catchphrase;
+  @NotBlank(message="Error: Prototype.concept can't blank")
   private String concept;
+  @NotBlank(message="Error: Prototype.image can't blank")
   private String image;
 }

--- a/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
@@ -2,6 +2,7 @@ package in.tech_camp.protospace_a.repository;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
@@ -9,6 +10,9 @@ import in.tech_camp.protospace_a.entity.PrototypeEntity;
 
 @Mapper
 public interface PrototypeRepository {
+  @Insert("INSERT INTO prototypes (name, catchphrase, concept, image) VALUES (#{name}, #{catchphrase}, #{concept}, #{image}) ")
+  void insertPrototype(PrototypeEntity prototype);
+
   // todo: user追加（user機能作成後）
   @Select("SELECT name, catchphrase, image FROM prototypes")
   List<PrototypeEntity> getAllPrototypes();

--- a/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
@@ -1,0 +1,15 @@
+package in.tech_camp.protospace_a.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import in.tech_camp.protospace_a.entity.PrototypeEntity;
+
+@Mapper
+public interface PrototypeRepository {
+  // todo: user追加（user機能作成後）
+  @Select("SELECT name, catchphrase, image FROM prototypes")
+  List<PrototypeEntity> getAllPrototypes();
+}

--- a/src/main/resources/templates/tmp/test.html
+++ b/src/main/resources/templates/tmp/test.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hello World</title>
 </head>
 <body>
-    <h1>Hello, World!</h1>
-    <p>このページは、シンプルな「Hello, World!」を表示するHTMLサンプルです。</p>
+    <h1>Hello, Prototype!</h1>
+    <p>これは、Prototypeの挙動を試すページです。</p>
+    <div xmlns:th="http://www.thymeleaf.org" th:fragment="form(actionUrl, prototypeForm)" >
+        <form th:action="${actionUrl}" th:method="post" th:object="${prototypeForm}">
+            <input type="text" th:field="*{name}" placeholder="name"/>
+            <input type="text" th:field="*{catchphrase}" placeholder="catchphrase"/>
+            <textarea th:field="*{concept}" placeholder="concept" rows="10"></textarea>
+            <input type="text" th:field="*{image}" placeholder="Image Url" />
+            <input type="submit" value="SEND" />
+        </form>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/tmp/test.html
+++ b/src/main/resources/templates/tmp/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    <h1>Hello, World!</h1>
+    <p>このページは、シンプルな「Hello, World!」を表示するHTMLサンプルです。</p>
+</body>
+</html>

--- a/src/main/resources/templates/tmp/test.html
+++ b/src/main/resources/templates/tmp/test.html
@@ -8,7 +8,12 @@
 <body>
     <h1>Hello, Prototype!</h1>
     <p>これは、Prototypeの挙動を試すページです。</p>
-    <div xmlns:th="http://www.thymeleaf.org" th:fragment="form(actionUrl, prototypeForm)" >
+    <ul>
+    <div xmlns:th="http://www.thymeleaf.org" th:fragment="form(actionUrl, prototypeForm, errors)" >
+        <th:block th:each="error : ${errors}">
+            <li th:text="${error}"></li>
+            </th:block>
+        </ul>
         <form th:action="${actionUrl}" th:method="post" th:object="${prototypeForm}">
             <input type="text" th:field="*{name}" placeholder="name"/>
             <input type="text" th:field="*{catchphrase}" placeholder="catchphrase"/>


### PR DESCRIPTION
# 工数
1h10min

# したこと
- PrototypeForm作成
- バリデーション作成（空文字列の場合のみ）

要件
- 必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプ情報がデータベースに保存されること。
- プロトタイプの名称が必須であること。
- キャッチコピーが必須であること。
- コンセプトの情報が必須であること。
- 画像は1枚必須であること。

# しないこと
- ログイン状態の場合のみ、投稿ページへ遷移できること。
- ログアウト状態で投稿ページに遷移しようとすると、ログインページに遷移すること。
->ログイン機能作成後

- 正しく投稿できた場合は、トップページへ遷移すること。
-> トップページ作成後

- 投稿に必要な情報が入力されていない場合は、投稿できずにそのページに留まること。
- バリデーションによって投稿ができず、そのページに留まった場合でも、入力済みの項目（画像以外）は消えないこと
-> プロトタイプの投稿画面作成後

# 挙動確認
1. `protospace`にPrototypeのデータを入力（確認作業のため適当でいいです）
2. アプリケーション起動
3. ブラウザで`localhost:8080`で表示
4. 
- 成功の場合、DBにプロトタイプのデータが保存されているかどうか
- 失敗の場合、各パラメータのエラーメッセージが表示される（バリデーションの場合のみ）