### PR TITLE
新規ユーザ登録のバリデーション機能作成

### DIFF
--- a/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
@@ -32,7 +32,7 @@ public class TestUserController {
 
   @GetMapping("/test/users/sign_up")
   public String showSignUp(Model model) {
-    model.addAttribute("userForm", new UserForm());
+    model.addAttribute("userForm", new UserForm(userRepository));
       return "tmp/signUp";
   }
   

--- a/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
@@ -38,7 +38,7 @@ public class TestUserController {
   
   @PostMapping("/test/user")
   public String createUser(@ModelAttribute("userForm") @Validated(ValidationOrder.class) UserForm userForm, BindingResult result, Model model) {
-    userForm.validatePasswordConfirmation(result);
+    userForm.validateUserForm(result);
     if (userRepository.existsByEmail(userForm.getEmail())) {
       result.rejectValue("email", "null", "Email already exists");
     }

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -1,12 +1,13 @@
 package in.tech_camp.protospace_a.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -43,11 +44,9 @@ public class UserController {
     userForm.validateUserForm(result);
 
     if (result.hasErrors()) {
-      List<String> errorMessages = result.getAllErrors().stream()
-              .map(DefaultMessageSourceResolvable::getDefaultMessage)
-              .collect(Collectors.toList());
-
-      model.addAttribute("errorMessages", errorMessages);
+      Map<String, String> fieldErrors = result.getFieldErrors().stream()
+              .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage, (msg1, msg2) -> msg1));
+      model.addAttribute("fieldErrors", fieldErrors);
       model.addAttribute("userForm", userForm);
       return "users/signUp";
     }

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
   
   @PostMapping("/user")
   public String createUser(@ModelAttribute("userForm") @Validated(ValidationOrder.class) UserForm userForm, BindingResult result, Model model) {
-    userForm.validatePasswordConfirmation(result);
+    userForm.validateUserForm(result);
     if (userRepository.existsByEmail(userForm.getEmail())) {
       result.rejectValue("email", "null", "Email already exists");
     }

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -34,16 +34,13 @@ public class UserController {
 
   @GetMapping("/users/sign_up")
   public String showSignUp(Model model) {
-    model.addAttribute("userForm", new UserForm());
+    model.addAttribute("userForm", new UserForm(userRepository));
       return "users/signUp";
   }
   
   @PostMapping("/user")
   public String createUser(@ModelAttribute("userForm") @Validated(ValidationOrder.class) UserForm userForm, BindingResult result, Model model) {
     userForm.validateUserForm(result);
-    if (userRepository.existsByEmail(userForm.getEmail())) {
-      result.rejectValue("email", "null", "Email already exists");
-    }
 
     if (result.hasErrors()) {
       List<String> errorMessages = result.getAllErrors().stream()

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -41,6 +41,7 @@ public class UserForm {
       
       if (30 < username.length()) {
         result.rejectValue("username", "username", "ユーザー名は 30 文字で指定してください");
+        return;
       }
     }
     
@@ -50,7 +51,12 @@ public class UserForm {
         return;
       }
 
-    if (!email.matches("^[a-z0-9.]+$")) {
+    if (email.chars().filter(c -> c == '@').count() != 1) {
+        result.rejectValue("email", "email", "メールアドレスには @ を1つだけ含めてください");
+        return;
+    }
+    
+    if (!email.matches("^[@a-z0-9.]+$")) {
         result.rejectValue("email", "email", "ASCII 文字 (a-z)、数字 (0-9)、およびピリオド (.) のみが使用できます");
         return;
     }
@@ -68,42 +74,56 @@ public class UserForm {
 
     char lastChar = email.charAt(email.length() - 1);
     if (!Character.isLowerCase(lastChar) && !Character.isDigit(lastChar)) {
-          result.rejectValue("email", "email", "メールアドレスの最後の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります。");
-      }
+          result.rejectValue("email", "email", "メールアドレスの最後の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります");
+        return;
+    }
 
     if (userRepository.existsByEmail(email)) {
-      result.rejectValue("email", "null", "このメールアドレスは既に使用されています。別のメールアドレスを作成してください。");
+      result.rejectValue("email", "null", "このメールアドレスは既に使用されています。別のメールアドレスを作成してください");
     }
   }
 
   public void validatePassword(BindingResult result) {
-    String allowedRegex = "^[A-Za-z0-9]+$";
-    boolean isValidCharacters = password.matches(allowedRegex);
-    
     if (password == null || password.isEmpty()) {
         result.rejectValue("password", "password", "パスワードを入力してください");
         return;
     }
     
-    if (!(isValidCharacters)) {
-      result.rejectValue("password", "password", 
-      "より強力なパスワードを選択してください。大小英字、数字の組み合わせをお試しください。");
-      return;
+    if (password.length() < 6) {
+        result.rejectValue("password", "password", "パスワードは 6 文字以上で設定してください");
+        return;
     }
-    
+
+    if (128 < password.length()) {
+        result.rejectValue("password", "password", "パスワードは 128 文字以下で設定してください");
+        return;
+    }
+
+    String allowedRegex = "^[A-Za-z0-9]+$";
+    boolean isValidCharacters = password.matches(allowedRegex);
+    boolean hasLowercase = password.matches(".*[a-z].*");
+    boolean hasUppercase = password.matches(".*[A-Z].*");
+    boolean hasDigit = password.matches(".*[0-9].*");
+    if (!(isValidCharacters && hasLowercase && hasUppercase && hasDigit)) {
+        result.rejectValue("password", "password",
+            "より強力なパスワードを選択してください。英小文字・英大文字・数字をそれぞれ1文字以上含めてください");
+        return;
+    }
+
     if (passwordConfirmation == null || passwordConfirmation.isEmpty()) {
         result.rejectValue("passwordConfirmation", "passwordConfirmation", "確認用のパスワードを入力してください");
         return;
     }
     
     if (!password.equals(passwordConfirmation)) {
-      result.rejectValue("passwordConfirmation", "password", "パスワードが一致しませんでした。もう一度お試しください。");
+      result.rejectValue("passwordConfirmation", "passwordConfirmation", "パスワードが一致しませんでした。もう一度お試しください。");
     }
   }
 
   public void validateProfile(BindingResult result) {
-    if (profile != null || profile.isEmpty()) {
+    if (profile == null || profile.isEmpty()) {
       result.rejectValue("profile", "profile", "プロフィールを入力してください");
+      return;
     }
 
     if (140 < profile.length()) {

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -12,9 +12,6 @@ import lombok.Data;
 public class UserForm {
   private String email;
   private String password;
-
-  @NotBlank(message = "Username can't be blank", groups = ValidationPriority1.class)
-  @Length(max = 50, message = "Username is too long", groups = ValidationPriority2.class)
   private String username;
 
   @NotBlank(message = "Profile can't be blank", groups = ValidationPriority1.class)
@@ -30,6 +27,17 @@ public class UserForm {
   @Autowired
   private final UserRepository userRepository;
 
+
+  public void validateUsername(BindingResult result) {
+    if (username == null || username.isEmpty()) {
+        result.rejectValue("username", "username", "ユーザー名を入力してください");
+        return;
+      }
+      
+      if (30 < username.length()) {
+        result.rejectValue("username", "username", "ユーザー名は 30 文字で指定してください");
+      }
+    }
     
   public void validateEmail(BindingResult result) {
     if (email == null || email.isEmpty()) {

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -22,9 +22,16 @@ public class UserForm {
   private String role;
 
   private String passwordConfirmation;
+
   @Autowired
   private final UserRepository userRepository;
 
+  public void validateUserForm(BindingResult result) {
+    validateEmail(result);
+    validatePassword(result);
+    validateUsername(result);
+    validateProfile(result);
+  }
 
   public void validateUsername(BindingResult result) {
     if (username == null || username.isEmpty()) {

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -14,9 +14,6 @@ public class UserForm {
   @NotBlank(message = "Email can't be blank", groups = ValidationPriority1.class)
   @Email(message = "Email should be valid", groups = ValidationPriority2.class)
   private String email;
-  
-  @NotBlank(message = "Password can't be blank", groups = ValidationPriority1.class)
-  @Length(min = 6, max = 128, message = "Password should be between 6 and 128 characters", groups = ValidationPriority2.class)
   private String password;
 
   @NotBlank(message = "Username can't be blank", groups = ValidationPriority1.class)
@@ -34,9 +31,28 @@ public class UserForm {
 
   private String passwordConfirmation;
 
-  public void validatePasswordConfirmation(BindingResult result) {
-      if (!password.equals(passwordConfirmation)) {
-          result.rejectValue("passwordConfirmation", null, "Password confirmation doesn't match Password");
-      }
+  public void validatePassword(BindingResult result) {
+    String allowedRegex = "^[A-Za-z0-9]+$";
+    boolean isValidCharacters = password.matches(allowedRegex);
+    
+    if (password == null || password.isEmpty()) {
+        result.rejectValue("password", "password", "パスワードを入力してください");
+        return;
+    }
+    
+    if (!(isValidCharacters)) {
+      result.rejectValue("password", "password", 
+      "より強力なパスワードを選択してください。大小英字、数字の組み合わせをお試しください。");
+      return;
+    }
+    
+    if (passwordConfirmation == null || passwordConfirmation.isEmpty()) {
+        result.rejectValue("passwordConfirmation", "passwordConfirmation", "確認用のパスワードを入力してください");
+        return;
+    }
+    
+    if (!password.equals(passwordConfirmation)) {
+      result.rejectValue("passwordConfirmation", "password", "パスワードが一致しませんでした。もう一度お試しください。");
+    }
   }
 }

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -1,18 +1,15 @@
 package in.tech_camp.protospace_a.form;
 
-import org.hibernate.validator.constraints.Length;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindingResult;
 
+import in.tech_camp.protospace_a.repository.UserRepository;
 import in.tech_camp.protospace_a.validation.ValidationPriority1;
-import in.tech_camp.protospace_a.validation.ValidationPriority2;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class UserForm {
-  @NotBlank(message = "Email can't be blank", groups = ValidationPriority1.class)
-  @Email(message = "Email should be valid", groups = ValidationPriority2.class)
   private String email;
   private String password;
 
@@ -30,6 +27,41 @@ public class UserForm {
   private String role;
 
   private String passwordConfirmation;
+  @Autowired
+  private final UserRepository userRepository;
+
+    
+  public void validateEmail(BindingResult result) {
+    if (email == null || email.isEmpty()) {
+        result.rejectValue("email", "email", "メールアドレスを入力してください");
+        return;
+      }
+
+    if (!email.matches("^[a-z0-9.]+$")) {
+        result.rejectValue("email", "email", "ASCII 文字 (a-z)、数字 (0-9)、およびピリオド (.) のみが使用できます");
+        return;
+    }
+
+    if (email.contains("..")) {
+        result.rejectValue("email", "email", "ピリオドを連続して使用することはできません");
+        return;
+    }
+
+    char firstChar = email.charAt(0);
+    if (!Character.isLowerCase(firstChar) && !Character.isDigit(firstChar)) {
+        result.rejectValue("email", "email", "メールアドレスの最初の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります");
+        return;
+    }
+
+    char lastChar = email.charAt(email.length() - 1);
+    if (!Character.isLowerCase(lastChar) && !Character.isDigit(lastChar)) {
+          result.rejectValue("email", "email", "メールアドレスの最後の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります。");
+      }
+
+    if (userRepository.existsByEmail(email)) {
+      result.rejectValue("email", "null", "このメールアドレスは既に使用されています。別のメールアドレスを作成してください。");
+    }
+  }
 
   public void validatePassword(BindingResult result) {
     String allowedRegex = "^[A-Za-z0-9]+$";

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -13,8 +13,6 @@ public class UserForm {
   private String email;
   private String password;
   private String username;
-
-  @NotBlank(message = "Profile can't be blank", groups = ValidationPriority1.class)
   private String profile;
 
   @NotBlank(message = "Company can't be blank", groups = ValidationPriority1.class)
@@ -93,6 +91,16 @@ public class UserForm {
     
     if (!password.equals(passwordConfirmation)) {
       result.rejectValue("passwordConfirmation", "password", "パスワードが一致しませんでした。もう一度お試しください。");
+    }
+  }
+
+  public void validateProfile(BindingResult result) {
+    if (profile != null || profile.isEmpty()) {
+      result.rejectValue("profile", "profile", "プロフィールを入力してください");
+    }
+
+    if (140 < profile.length()) {
+      result.rejectValue("profile", "profile", "プロフィールの文字数は140字以内で入力してください");
     }
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1425,3 +1425,8 @@ form input[type="file"] {
 
   padding-bottom: 30px;
 }
+
+.error_message {
+  color: red;
+  font-size: 12px;
+}

--- a/src/main/resources/templates/prototypes/detail.html
+++ b/src/main/resources/templates/prototypes/detail.html
@@ -34,7 +34,7 @@
       <p class="concept" th:text="${prototype.concept}"></p>
     </div>
     <div class="container">
-      <span th:if="${errorMessages}" style="color:red;" th:text="${errorMessages}"></span>
+      <span th:if="${errorMessages}" th:text="${errorMessages}" class="error_message"></span>
       <p>コメント</p>
       <div th:if="${#authorization.expression('isAuthenticated()')}">
       <form th:action="@{/prototypes/{prototypeId}/comment(prototypeId=${prototype.id})}" 

--- a/src/main/resources/templates/tmp/login.html
+++ b/src/main/resources/templates/tmp/login.html
@@ -16,7 +16,7 @@
             <input type="password" name="password" required/>
         </div>
         <div th:if="${loginError}">
-            <span th:text="${loginError}" style="color:red"></span>
+            <span class="error_message">メールアドレスまたはパスワードが正しくありません。</span>
         </div>
         <button type="submit">Log in</button>
     </form>

--- a/src/main/resources/templates/users/login.html
+++ b/src/main/resources/templates/users/login.html
@@ -13,18 +13,20 @@
 <div class="main_contents">
   <div class="container_Form">
     <h2>ユーザーログイン</h2>
-    <p th:if="${loginError}" class="login-error" th:text="${loginError}"></p>
-
     <form th:method="post" th:action="@{/login}" class="new_user">
-
+      
       <div class="field">
         <label class="column-title">メールアドレス</label><br />
         <input type="email" id="email" name="email" autofocus="autofocus" required="required" />
       </div>
-
+      
       <div class="field">
-        <label class="password">パスワード（6文字以上）</label><br />
+        <label class="password">パスワード</label><br />
         <input type="password" name="password" required="required" autocomplete="off" />
+      </div>
+
+      <div th:if="${loginError}">
+          <span class="error_message">メールアドレスまたはパスワードが正しくありません。</span>
       </div>
 
       <div class="actions">

--- a/src/main/resources/templates/users/signUp.html
+++ b/src/main/resources/templates/users/signUp.html
@@ -14,21 +14,19 @@
   <div class="container_Form">
     <h2>ユーザー新規登録</h2>
     <div class="form">
-      <div th:if="${errorMessages}" th:each="error : ${errorMessages}">
-        <div th:text="${error}"></div>
-      </div>
       <form th:action="@{/user}" th:method="post" th:object="${userForm}", class="new_user">
         
         <div class="field">
           <label for="email">メールアドレス</label><br />
           <input type="email" id="email" th:field="*{email}"  />
+          <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'email')}" th:text="＊ + ${fieldErrors['email']}" class="error_message"></div>
         </div>
-
+        
         <div class="field">
           <label for="password">パスワード</label><em>(6文字以上)</em><br />
           <input type="password" id="password" th:field="*{password}" />
         </div>
-
+        
         <div class='field'>
           <div class='field-label'>
             <label for="password_confirmation">パスワード再入力</label>
@@ -36,16 +34,20 @@
           <div class='field-input'>
             <input type="password" th:field="*{passwordConfirmation}" id="password_confirmation" autocomplete="off"/>
           </div>
+          <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'password')}" th:text="＊ + ${fieldErrors['password']}" class="error_message"></div>
+          <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'passwordConfirmation')}" th:text="＊ + ${fieldErrors['passwordConfirmation']}" class="error_message"></div>
         </div>
-
+        
         <div class="field">
           <label for="username">ユーザー名</label><br />
           <input type="text" id="username" th:field="*{username}"  autofocus="autofocus" />
+          <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'username')}" th:text="＊ + ${fieldErrors['username']}" class="error_message"></div>
         </div>
-
+        
         <div class="field">
           <label for="profile">プロフィール</label><br />
           <input type="text" id="profile" th:field="*{profile}"  autofocus="autofocus" />
+          <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'profile')}" th:text="＊ + ${fieldErrors['profile']}" class="error_message"></div>
         </div>
 
         <div class="field">

--- a/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
@@ -3,21 +3,23 @@ package in.tech_camp.protospace_a.form;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 
 import in.tech_camp.protospace_a.repository.UserRepository;
 import in.tech_camp.protospace_a.validation.ValidationPriority1;
-import in.tech_camp.protospace_a.validation.ValidationPriority2;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
+@SpringBootTest
 public class UserFormUnitTest {
 
     private Validator validator;
@@ -25,106 +27,224 @@ public class UserFormUnitTest {
     @Autowired
     private UserRepository userRepository;
 
+    private UserForm form;
+    private BindingResult result;
+
     @BeforeEach
     void setup() {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
+        form = createValidUserForm();
+        result = new BeanPropertyBindingResult(form, "userForm");
     }
 
     @Test
-    public void 入力が全て正しい場合バリデーションエラーにならない() {
-        UserForm form = createValidUserForm();
-
-        // グループ1（必須チェックなど）とグループ2（形式や文字数チェックなど）の両方を検証
-        Set<ConstraintViolation<UserForm>> violationsPriority1 = validator.validate(form, ValidationPriority1.class);
-        Set<ConstraintViolation<UserForm>> violationsPriority2 = validator.validate(form, ValidationPriority2.class);
-
-        assertTrue(violationsPriority1.isEmpty(), "ValidationPriority1でバリデーションエラーが発生しています");
-        assertTrue(violationsPriority2.isEmpty(), "ValidationPriority2でバリデーションエラーが発生しています");
-
-        // パスワード確認の手動バリデーション
-        BindingResult result = new BeanPropertyBindingResult(form, "userForm");
-        form.validatePassword(result);
-        assertTrue(!result.hasFieldErrors("passwordConfirmation"), "パスワード確認でバリデーションエラーが発生しています");
+    public void 入力が正しい場合成功() {
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("username"));
+        assertFalse(result.hasFieldErrors("email"));
+        assertFalse(result.hasFieldErrors("password"));
+        assertFalse(result.hasFieldErrors("profile"));
     }
 
     @Test
-    public void emailが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
+    public void emailが空の場合エラー() {
         form.setEmail("");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Email can't be blank", violations.iterator().next().getMessage());
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("メールアドレスを入力してください", result.getFieldError("email").getDefaultMessage());
     }
-
+    
     @Test
-    public void emailが不正な形式ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
+    public void emailにアットマークが含まれていない場合エラー() {
         form.setEmail("invalid-email");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority2.class);
-        assertEquals(1, violations.size());
-        assertEquals("Email should be valid", violations.iterator().next().getMessage());
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("メールアドレスには @ を1つだけ含めてください", result.getFieldError("email").getDefaultMessage());
     }
 
     @Test
-    public void passwordが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
+    public void emailが英字数字ドット以外の文字が含まれている場合エラー() {
+        form.setEmail("t?est@test.com");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("ASCII 文字 (a-z)、数字 (0-9)、およびピリオド (.) のみが使用できます", result.getFieldError("email").getDefaultMessage());
+    }
+
+    @Test
+    public void emailの最初の文字が英字数字以外の場合エラー() {
+        form.setEmail(".test@test.com");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("メールアドレスの最初の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります", result.getFieldError("email").getDefaultMessage());
+    }
+
+    @Test
+    public void emailの最後の文字が英字数字以外の場合エラー() {
+        form.setEmail("test@test.com.");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("メールアドレスの最後の文字は、ASCII 文字（a-z）または数字（0-9）にする必要があります", result.getFieldError("email").getDefaultMessage());
+    }
+
+    @Test
+    public void emailのドットが連続して含まれている場合エラー() {
+        form.setEmail("test@test..com");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("email"));
+        assertEquals("ピリオドを連続して使用することはできません", result.getFieldError("email").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordが空の場合エラー() {
         form.setPassword("");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Password can't be blank", violations.iterator().next().getMessage());
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("パスワードを入力してください", result.getFieldError("password").getDefaultMessage());
     }
 
     @Test
-    public void passwordが6文字未満ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
-        form.setPassword("123");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority2.class);
-        assertEquals(1, violations.size());
-        assertEquals("Password should be between 6 and 128 characters", violations.iterator().next().getMessage());
+    public void passwordが5文字の場合エラー() {
+        form.setPassword("1".repeat(5));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("パスワードは 6 文字以上で設定してください", result.getFieldError("password").getDefaultMessage());
     }
 
     @Test
-    public void passwordとpasswordConfirmationが一致しない場合エラーになる() {
-        UserForm form = createValidUserForm();
+    public void passwordが6文字の場合成功() {
+        form.setPassword("1aA".repeat(6));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("password"));
+    }
+
+    @Test
+    public void passwordが128文字の場合成功() {
+        form.setPassword("1".repeat(126) + "a" + "A");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("password"));
+    }
+    
+    @Test
+    public void passwordが129文字の場合エラー() {
+        form.setPassword("1".repeat(129));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("パスワードは 128 文字以下で設定してください",  result.getFieldError("password").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordが小文字のみの場合エラー() {
+        form.setPassword("a".repeat(6));
+        form.setPasswordConfirmation("a".repeat(6));
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("より強力なパスワードを選択してください。英小文字・英大文字・数字をそれぞれ1文字以上含めてください", result.getFieldError("password").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordが大文字のみの場合エラー() {
+        form.setPassword("A".repeat(6));
+        form.setPasswordConfirmation("A".repeat(6));
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("より強力なパスワードを選択してください。英小文字・英大文字・数字をそれぞれ1文字以上含めてください", result.getFieldError("password").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordが数字のみの場合エラー() {
+        form.setPassword("1".repeat(6));
+        form.setPasswordConfirmation("1".repeat(6));
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("password"));
+        assertEquals("より強力なパスワードを選択してください。英小文字・英大文字・数字をそれぞれ1文字以上含めてください", result.getFieldError("password").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordConfirmationが空の場合エラー() {
+        form.setPasswordConfirmation("");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("passwordConfirmation"));
+        assertEquals("確認用のパスワードを入力してください", result.getFieldError("passwordConfirmation").getDefaultMessage());
+    }
+
+    @Test
+    public void passwordとpasswordConfirmationが一致しない場合エラー() {
         form.setPassword("techcamp123");
         form.setPasswordConfirmation("different");
-
-        BindingResult result = new BeanPropertyBindingResult(form, "userForm");
-        form.validatePassword(result);
-
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
         assertTrue(result.hasFieldErrors("passwordConfirmation"));
-        assertEquals("Password confirmation doesn't match Password",
-                result.getFieldError("passwordConfirmation").getDefaultMessage());
+        assertEquals("パスワードが一致しませんでした。もう一度お試しください。", result.getFieldError("passwordConfirmation").getDefaultMessage());
     }
 
     @Test
-    public void usernameが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
+    public void usernameが空の場合エラー() {
         form.setUsername("");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Username can't be blank", violations.iterator().next().getMessage());
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("username"));
+        assertEquals("ユーザー名を入力してください", result.getFieldError("username").getDefaultMessage());
     }
 
     @Test
-    public void profileが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
-        form.setProfile("");
+    public void usernameの文字数が30文字の場合成功() {
+        form.setUsername("あ".repeat(30));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("username"));
+    }
 
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Profile can't be blank", violations.iterator().next().getMessage());
+    @Test
+    public void usernameの文字数が31文字の場合エラー() {
+        form.setUsername("あ".repeat(31));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("username"));
+        assertEquals("ユーザー名は 30 文字で指定してください", result.getFieldError("username").getDefaultMessage());
+    }
+
+    @Test
+    public void profileが空の場合エラー() {
+        form.setProfile("");
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("profile"));
+        assertEquals("プロフィールを入力してください", result.getFieldError("profile").getDefaultMessage());
+    }
+
+    @Test
+    public void profileの文字数が140文字の場合成功() {
+        form.setProfile("あ".repeat(140));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("profile"));
+    }
+
+    @Test
+    public void profileの文字数が141文字の場合エラー() {
+        form.setProfile("あ".repeat(141));
+        result = new BeanPropertyBindingResult(form, "userForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("profile"));
+        assertEquals("プロフィールの文字数は140字までです", result.getFieldError("profile").getDefaultMessage());
     }
 
     @Test
     public void companyが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
         form.setCompany("");
 
         Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
@@ -134,7 +254,6 @@ public class UserFormUnitTest {
 
     @Test
     public void roleが空ならバリデーションエラーになる() {
-        UserForm form = createValidUserForm();
         form.setRole("");
 
         Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
@@ -145,8 +264,8 @@ public class UserFormUnitTest {
     private UserForm createValidUserForm() {
         UserForm form = new UserForm(userRepository);
         form.setEmail("test@example.com");
-        form.setPassword("techcamp123");
-        form.setPasswordConfirmation("techcamp123");
+        form.setPassword("1aA".repeat(6));
+        form.setPasswordConfirmation("1aA".repeat(6));
         form.setUsername("TestUser");
         form.setProfile("テストプロフィール");
         form.setCompany("TechCamp");

--- a/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
@@ -39,7 +39,7 @@ public class UserFormUnitTest {
 
         // パスワード確認の手動バリデーション
         BindingResult result = new BeanPropertyBindingResult(form, "userForm");
-        form.validatePasswordConfirmation(result);
+        form.validatePassword(result);
         assertTrue(!result.hasFieldErrors("passwordConfirmation"), "パスワード確認でバリデーションエラーが発生しています");
     }
 
@@ -90,7 +90,7 @@ public class UserFormUnitTest {
         form.setPasswordConfirmation("different");
 
         BindingResult result = new BeanPropertyBindingResult(form, "userForm");
-        form.validatePasswordConfirmation(result);
+        form.validatePassword(result);
 
         assertTrue(result.hasFieldErrors("passwordConfirmation"));
         assertEquals("Password confirmation doesn't match Password",

--- a/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 
+import in.tech_camp.protospace_a.repository.UserRepository;
 import in.tech_camp.protospace_a.validation.ValidationPriority1;
 import in.tech_camp.protospace_a.validation.ValidationPriority2;
 import jakarta.validation.ConstraintViolation;
@@ -19,6 +21,9 @@ import jakarta.validation.ValidatorFactory;
 public class UserFormUnitTest {
 
     private Validator validator;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @BeforeEach
     void setup() {
@@ -138,7 +143,7 @@ public class UserFormUnitTest {
     }
 
     private UserForm createValidUserForm() {
-        UserForm form = new UserForm();
+        UserForm form = new UserForm(userRepository);
         form.setEmail("test@example.com");
         form.setPassword("techcamp123");
         form.setPasswordConfirmation("techcamp123");


### PR DESCRIPTION
## したこと
新規登録ユーザーのユーザー名、メールアドレス、パスワード、確認用パスワード、プロフィールのバリデーションを作成しました。

- エラーメッセージを日本語
- エラーメッセージを赤色  
- 各フィールドのエラーメッセージ作成 

## してないこと
- 新規登録画面にパスワードの設定文言の作成
- 会社名、役職のバリデーション機能を作成（プロフィールで記載できるため、削除する想定）
- ユーザー名の一意のバリデーション 

# 挙動確認
![Screenshot 2025-06-26 110656](https://github.com/user-attachments/assets/cc4fe0e3-8eda-4c8e-b6ad-467cd5084339)

#### ユーザ名
- [ ] 空文字
- [ ] 30字数以上

#### メール
- [ ] 空文字
- [ ] ASCII 文字 (a-z)、数字 (0-9)、およびピリオド (.) 以外の文字
- [ ]  ASCII 文字 (a-z)必須
- [ ] 数字 (0-9)必須
- [ ] ピリオド(.)必須
- [ ] 連続ピリオド不可
- [ ] 最初と最後のの文字は、ASCII 文字（a-z）または数字（0-9）
- [ ] 一意制約（重複しない）

#### パスワード
- [ ] 空文字
- [ ] 小文字は必須
- [ ] 大文字は必須
- [ ] 数字は必須
- [ ] パスワードの最小文字数を6文字
- [ ] パスワードの最大文字数を128 文字
- [ ] 確認用とのパスワードの一致
