### PR TITLE
ログインユーザーのバリデーション時のエラーメッセージ修正

### DIFF
--- a/src/main/resources/templates/tmp/login.html
+++ b/src/main/resources/templates/tmp/login.html
@@ -16,7 +16,7 @@
             <input type="password" name="password" required/>
         </div>
         <div th:if="${loginError}">
-            <span th:text="${loginError}" style="color:red"></span>
+            <span class="error_message">メールアドレスまたはパスワードが正しくありません。</span>
         </div>
         <button type="submit">Log in</button>
     </form>

--- a/src/main/resources/templates/users/login.html
+++ b/src/main/resources/templates/users/login.html
@@ -13,18 +13,20 @@
 <div class="main_contents">
   <div class="container_Form">
     <h2>ユーザーログイン</h2>
-    <p th:if="${loginError}" class="login-error" th:text="${loginError}"></p>
-
     <form th:method="post" th:action="@{/login}" class="new_user">
-
+      
       <div class="field">
         <label class="column-title">メールアドレス</label><br />
         <input type="email" id="email" name="email" autofocus="autofocus" required="required" />
       </div>
-
+      
       <div class="field">
         <label class="password">パスワード（6文字以上）</label><br />
         <input type="password" name="password" required="required" autocomplete="off" />
+      </div>
+
+      <div th:if="${loginError}">
+          <span class="error_message">メールアドレスまたはパスワードが正しくありません。</span>
       </div>
 
       <div class="actions">

--- a/src/main/resources/templates/users/login.html
+++ b/src/main/resources/templates/users/login.html
@@ -21,7 +21,7 @@
       </div>
       
       <div class="field">
-        <label class="password">パスワード（6文字以上）</label><br />
+        <label class="password">パスワード</label><br />
         <input type="password" name="password" required="required" autocomplete="off" />
       </div>
 


### PR DESCRIPTION
したこと
ログインユーザーのエラーメッセージ修正しました。
- 日本語
- 赤字
- パスワードに記載されていた”6文字以上”を削除

してないこと
- テスト作成

挙動確認
![Screenshot 2025-06-26 160537](https://github.com/user-attachments/assets/33b3c289-fa03-4882-9a7d-82c338c5b86c)
