### PR TITLE
検索文字数50文字制限と検索一覧を横並びにする修正

### DIFF
--- a/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/PrototypeController.java
@@ -198,6 +198,11 @@ public class PrototypeController {
   // 検索機能
   @GetMapping("/prototypes/search")
   public String searchPrototypes(@ModelAttribute("searchForm") SearchForm searchForm, Model model) {
+    // 名前の長さ判定、50以上だったら、プリントアウト
+    if (searchForm.getName() != null && searchForm.getName().length() > 50) {
+      System.out.println(String.format("検索に入力した名前の文字数：%d、50を超えています!!", searchForm.getName().length()));
+  }
+
     List<PrototypeEntity> prototypes = prototypeRepository.findByNameContaining(searchForm.getName());
     model.addAttribute("prototypes", prototypes);
     model.addAttribute("searchForm", searchForm);

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -105,12 +105,18 @@ public class UserController {
     // 検索機能
     @GetMapping("/users/{userId}/search")
     public String searchPrototypes(@PathVariable("userId") Integer userId, @ModelAttribute("searchForm") SearchForm searchForm, Model model) {
-    UserEntity user = userRepository.findById(userId);
+      // 名前の長さ判定、50以上だったら、プリントアウト
+      if (searchForm.getName() != null && searchForm.getName().length() > 50) {
+        System.out.println(String.format("検索に入力した名前の文字数：%d、50を超えています!!", searchForm.getName().length()));
+
+    }
+
+      UserEntity user = userRepository.findById(userId);
       List<PrototypeEntity> prototypes = prototypeRepository.findByUserIdAndNameContaining(userId, searchForm.getName());
 
-    model.addAttribute("name", user.getUsername());
-    model.addAttribute("prototypes", prototypes);
-    model.addAttribute("searchForm", searchForm);
-    return "users/userInfo";
+      model.addAttribute("name", user.getUsername());
+      model.addAttribute("prototypes", prototypes);
+      model.addAttribute("searchForm", searchForm);
+      return "users/userInfo";
     }
 }

--- a/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
@@ -80,21 +80,17 @@ public interface PrototypeRepository {
   List<PrototypeEntity> findByNameContaining(String name);
 
 // ユーザーの詳細ページにて検索機能
-// @Select("SELECT * FROM prototypes WHERE user_id = #{userId} AND name LIKE CONCAT('%', #{name}, '%')")
-// List<PrototypeEntity> findByUserIdAndNameContaining(@Param("userId") Integer userId, @Param("name") String name);
-@Select("SELECT p.*, u.id as user_id, u.username as user_name " +
+  @Select("SELECT p.*, u.id as user_id, u.username as user_name " +
         "FROM prototypes p " +
         "LEFT JOIN users u ON p.user_id = u.id " +
         "WHERE p.user_id = #{userId} AND p.name LIKE CONCAT('%', #{name}, '%')")
-@Results({
+  @Results({
     @Result(property = "id", column = "id"),
     @Result(property = "name", column = "name"),
-    // 下面是User的映射
     @Result(property = "user.id", column = "user_id"),
     @Result(property = "user.username", column = "username")
-    // 你可以根据需要添加其他字段映射
-})
-List<PrototypeEntity> findByUserIdAndNameContaining(@Param("userId") Integer userId, @Param("name") String name);
+  })
+  List<PrototypeEntity> findByUserIdAndNameContaining(@Param("userId") Integer userId, @Param("name") String name);
 
 
 

--- a/src/main/resources/templates/prototypes/search.html
+++ b/src/main/resources/templates/prototypes/search.html
@@ -17,6 +17,23 @@
 </form>
   
 <div class="main_contents">
+
+<div class="protos">
+  <div class="proto" th:each="prototype : ${prototypes}">
+    <a th:href="@{'/prototypes/' + ${prototype.id}}">
+      <img th:src="@{${prototype.image}}" alt="プロトタイプ画像">
+    </a>
+    <h2 class="title" th:text="${prototype.name}"></h2>
+    <p class="catchcopy" th:text="${prototype.catchphrase}"></p>
+    <p class="author">
+      <a th:href="@{'/users/' + ${prototype.user.id}}" th:text="${prototype.user.username}"></a>
+    </p>
+  </div>
+</div>
+
+</div>
+
+<!-- <div class="main_contents">
   <div class="proto-detail" th:each="prototype: ${prototypes}">
     <div class="proto_info">
       <h2 class="title" th:text="${prototype.name}"></h2>
@@ -39,7 +56,7 @@
       <p class="concept" th:text="${prototype.concept}"></p>
     </div>
     <div class="container">
-      <span th:if="${errorMessages}" style="color:red;" th:text="${errorMessages}"></span>
+      <span th:if="${errorMessages}" style="color:red;" th:text="${errorMessages}"></span> -->
 
     </div>
   </div>


### PR DESCRIPTION
# したこと

- 検索文字数50文字制限
(50文字以上の場合は処理を裏にログを残す。)
- toppage検索一覧を横並びにする
