### PR TITLE
投稿時間の更新時間修正

### DIFF
--- a/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/PrototypeRepository.java
@@ -60,7 +60,7 @@ public interface PrototypeRepository {
   })
   PrototypeEntity findById(Integer id);
 
-  @Select("SELECT * FROM prototypes WHERE user_id = #{userId}")
+  @Select("SELECT * FROM prototypes WHERE user_id = #{userId} ORDER BY created_at DESC")
   @Results(value = {
     @Result(property = "user", column = "user_id",
             one = @One(select = "in.tech_camp.protospace_a.repository.UserRepository.findById"))

--- a/src/main/resources/templates/prototypes/detail.html
+++ b/src/main/resources/templates/prototypes/detail.html
@@ -18,8 +18,14 @@
   
       <a th:if="${#dates.format(prototype.updated_at, 'yyyy-MM-dd HH:mm:ss') == '1970-01-01 00:00:01'}"
         th:text="'作成時間：' + ${#dates.format(prototype.created_at, 'yyyy/M/d HH:mm')}"></a>
-      <a th:if="${#dates.format(prototype.updated_at, 'yyyy-MM-dd HH:mm:ss') != '1970-01-01 00:00:01'}"
-        th:text="'編集時間：' + ${#dates.format(prototype.updated_at, 'yyyy/M/d HH:mm')}"></a>
+        
+        <a th:if="${#dates.format(prototype.updated_at, 'yyyy-MM-dd HH:mm:ss') != '1970-01-01 00:00:01'}"
+   th:text="'作成時間：' + ${#dates.format(prototype.created_at, 'yyyy/M/d HH:mm')} + '　更新時間：' + ${#dates.format(prototype.updated_at, 'yyyy/M/d HH:mm')}">
+</a>
+
+      <!-- <a th:if="${#dates.format(prototype.updated_at, 'yyyy-MM-dd HH:mm:ss') != '1970-01-01 00:00:01'}"
+        th:text="'作成時間：' + ${#dates.format(prototype.created_at, 'yyyy/M/d HH:mm')}"
+        th:text="'更新時間：' + ${#dates.format(prototype.updated_at, 'yyyy/M/d HH:mm')}"></a> -->
 
       <p class="author">
           <a th:href="@{'/users/' + ${prototype.user.id}}" th:text="'by ' + ${prototype.user.username}"></a>


### PR DESCRIPTION
# したこと

- 投稿時間表示
作成だったら、作成時間のみ表示
編集だったら、作成時間と編集時間両方表示

- エラー修正
投稿内容を作成時間に基づいて、並び変え

![屏幕截图 2025-06-30 095721](https://github.com/user-attachments/assets/d97c11bd-8f6a-46a8-bcf2-7314c00d87ac)
![屏幕截图 2025-06-30 095753](https://github.com/user-attachments/assets/339f2769-491c-423c-81bd-11e7f06acae3)
