### PR TITLE
コメント投稿時のリダイレクトページ変更

### DIFF
--- a/src/main/java/in/tech_camp/protospace_a/SecurityConfig.java
+++ b/src/main/java/in/tech_camp/protospace_a/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
             .requestMatchers("/css/**", "/test/**", "/uploads/**", "/",
                 "/users/sign_up", "/users/login", "/prototypes/{id:[0-9]+}",
                 "/users/{id:[0-9]+}", "/prototypes/search",
-                "/users/{id:[0-9]+}/search")
+                "/users/{id:[0-9]+}/search", "/prototypes/{prototypesId:[0-9]+}/comments/{commentsId:[0-9]+}")
             .permitAll().requestMatchers(HttpMethod.POST, "/user").permitAll()
             .anyRequest().authenticated())
         .formLogin(login -> login.loginProcessingUrl("/login")

--- a/src/main/java/in/tech_camp/protospace_a/controller/CommentController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/CommentController.java
@@ -143,10 +143,10 @@ public class CommentController {
     }
     catch (Exception e) {
       System.out.println("Error：" + e);
-      return "redirect:/prototypes/" + prototypeId;
+      return "redirect:/prototypes/" + prototypeId + "/comments/" + comment.getId();
     }
 
-    return "redirect:/prototypes/" + prototypeId;
+    return "redirect:/prototypes/" + prototypeId + "/comments/" + comment.getId();
   }
 
   // コメントの更新処理
@@ -200,9 +200,9 @@ public class CommentController {
     }
     catch (Exception e) {
       System.err.println("Error: " + e);
-      return "redirect:/prototypes/" + prototypeId;
+      return "redirect:/prototypes/" + prototypeId + "/comments/" + commentId;
     }
-    return "redirect:/prototypes/" + prototypeId;
+    return "redirect:/prototypes/" + prototypeId + "/comments/" + commentId;
   }
 
   // コメント削除

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1623,7 +1623,7 @@ form input[type="file"] {
   font-size: 15px;
   text-decoration: none;
   display: inline-block;
-  color: #d6d6d6;
+  color: #000000;
 }
 
 .comment_text {

--- a/src/main/resources/templates/comments/detail.html
+++ b/src/main/resources/templates/comments/detail.html
@@ -32,7 +32,7 @@
             <span class="comment_btn_group"
               th:if="${#authorization.expression('isAuthenticated()') and #authentication?.principal.id == comment.user.id}">
               <a class="comment_btn"
-                th:href="@{/prototypes/{prototypeId}/comments/{co mmentId}/edit(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
+                th:href="@{/prototypes/{prototypeId}/comments/{commentId}/edit(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
                 th:text="編集">
               </a>
               <a class="comment_btn"

--- a/src/main/resources/templates/comments/detail.html
+++ b/src/main/resources/templates/comments/detail.html
@@ -18,34 +18,32 @@
           <p class="author">
             <a th:href="@{'/users/' + ${prototype.user.id}}" th:text="'by ' + ${prototype.user.username}"></a>
           </p>
-          <img th:src="@{${prototype.image}}" alt="プロトタイプ画像">
-          <h2 class="sub-title">キャッチコピー</h2>
-          <p class="catchcopy" th:text="${prototype.catchphrase}"></p>
-          <h2 class="sub-title">コンセプト</h2>
-          <p class="concept" th:text="${prototype.concept}"></p>
+          <a th:href="@{/prototypes/{prototypeId}(prototypeId = ${prototype.id})}">
+            <img th:src="@{${prototype.image}}" alt="プロトタイプ画像">
+          </a>
         </div>
 
         <div class="container_comment">
-          <span class="comment_btn_group"
-            th:if="${#authorization.expression('isAuthenticated()') and #authentication?.principal.id == comment.user.id}">
-            <a class="comment_btn"
-              th:href="@{/prototypes/{prototypeId}/comments/{commentId}/edit(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
-              th:text="編集">
-            </a>
-            <a class="comment_btn"
-              th:href="@{/prototypes/{prototypeId}/comments/{commentId}/delete(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
-              th:text="削除">
-            </a>
-          </span>
+          <div class="comment_top">
+            <p class="comment_author">
+              <a th:href="@{/users/{userId}(userId = ${comment.user.id})}"
+                th:text="${comment.user.username} + ' さんのコメント'"></a>
+            </p>
+            <span class="comment_btn_group"
+              th:if="${#authorization.expression('isAuthenticated()') and #authentication?.principal.id == comment.user.id}">
+              <a class="comment_btn"
+                th:href="@{/prototypes/{prototypeId}/comments/{co mmentId}/edit(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
+                th:text="編集">
+              </a>
+              <a class="comment_btn"
+                th:href="@{/prototypes/{prototypeId}/comments/{commentId}/delete(prototypeId = ${prototype.id}, commentId = ${comment.id})}"
+                th:text="削除">
+              </a>
+            </span>
+          </div>
           <div class="container_comment_detail">
             <div class="comment_title">
-              <p th:text="${comment.title}"></p>
-
-              <p class="comment_author">
-                <a th:href="@{/users/{userId}(userId = ${comment.user.id})}"
-                  th:text="'by ' + ${comment.user.username}"></a>
-              </p>
-
+              <p th:text="${comment.title}"></p>  
             </div>
             <span class="comment_text" th:text="${comment.content}"></span>
           </div>


### PR DESCRIPTION
したこと
・コメント投稿/更新後のリダイレクトページをプロトタイプ詳細ページからコメント詳細ページに変更

・コメント詳細ページのプロトタイプ情報を簡略に変更
・コメント詳細情報のレイアウトをより分かりやすいように変更
![image](https://github.com/user-attachments/assets/954e4c7a-e6b4-43a4-8b05-40ded41bbef8)

してないこと
・コメント一覧のデザイン変更(ユーザー情報編集などの実装後にする予定)
・SNS認証 (まだ関連情報を調べている途中)