### PR TITLE
ユーザー編集機能作成

### DIFF
--- a/design/db.md
+++ b/design/db.md
@@ -7,8 +7,7 @@
 | email | VARCHAR(128)    | NOT NULL UNIQUE |
 | password | VARCHAR(128)    | NOT NULL |
 | profile | VARCHAR(128)    | NOT NULL |
-| company | VARCHAR(50)    | NOT NULL |
-| role | VARCHAR(50)    | NOT NULL |
+| profile_image | VARCHAR(256) | |;
 
 
 ### Option

--- a/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/TestUserController.java
@@ -60,9 +60,6 @@ public class TestUserController {
     userEntity.setEmail(userForm.getEmail());
     userEntity.setPassword(userForm.getPassword());
     userEntity.setProfile(userForm.getProfile());
-    userEntity.setCompany(userForm.getCompany());
-    userEntity.setRole(userForm.getRole());
-
 
     try {
       userService.createUserWithEncryptedPassword(userEntity);
@@ -100,8 +97,6 @@ public class TestUserController {
 
     model.addAttribute("nickname", user.getUsername());
     model.addAttribute("profile", user.getProfile());
-    model.addAttribute("role", user.getRole());
-    model.addAttribute("company", user.getCompany());
     model.addAttribute("prototypes", prototypes);
     return "tmp/users/mypage";
   }

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -60,9 +60,6 @@ public class UserController {
     userEntity.setEmail(userForm.getEmail());
     userEntity.setPassword(userForm.getPassword());
     userEntity.setProfile(userForm.getProfile());
-    userEntity.setCompany(userForm.getCompany());
-    userEntity.setRole(userForm.getRole());
-
 
     try {
       userService.createUserWithEncryptedPassword(userEntity);
@@ -100,8 +97,6 @@ public class UserController {
 
     model.addAttribute("name", user.getUsername());
     model.addAttribute("profile", user.getProfile());
-    model.addAttribute("role", user.getRole());
-    model.addAttribute("company", user.getCompany());
     model.addAttribute("prototypes", prototypes);
     return "users/userInfo";
   }

--- a/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
+++ b/src/main/java/in/tech_camp/protospace_a/controller/UserController.java
@@ -1,5 +1,11 @@
 package in.tech_camp.protospace_a.controller;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,7 +20,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
+import in.tech_camp.protospace_a.ImageUrl;
 import in.tech_camp.protospace_a.entity.PrototypeEntity;
 import in.tech_camp.protospace_a.entity.UserEntity;
 import in.tech_camp.protospace_a.form.SearchForm;
@@ -33,6 +41,7 @@ public class UserController {
   private final PrototypeRepository prototypeRepository;
   private final UserRepository userRepository;
   private final UserService userService;
+  private final ImageUrl imageUrl;
 
   @GetMapping("/users/sign_up")
   public String showSignUp(Model model) {
@@ -60,6 +69,29 @@ public class UserController {
     userEntity.setEmail(userForm.getEmail());
     userEntity.setPassword(userForm.getPassword());
     userEntity.setProfile(userForm.getProfile());
+    
+    MultipartFile imageFile = userForm.getProfileImage();
+    if (imageFile != null && !imageFile.isEmpty()) {
+      try {
+        String uploadDir = imageUrl.getImageUrl();
+
+        Path uploadDirPath = Paths.get(uploadDir);
+        if (!Files.exists(uploadDirPath)) {
+          Files.createDirectories(uploadDirPath);
+        }
+
+        String fileName = LocalDateTime.now()
+            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + "_"
+            + imageFile.getOriginalFilename();
+        Path imagePath = Paths.get(uploadDir, fileName);
+        Files.copy(imageFile.getInputStream(), imagePath);
+        userEntity.setProfileImage("/uploads/userprofiles" + fileName);
+      }
+      catch (IOException e) {
+        System.out.println("Error：" + e);
+        return "users/new";
+      }
+    }
 
     try {
       userService.createUserWithEncryptedPassword(userEntity);

--- a/src/main/java/in/tech_camp/protospace_a/entity/UserEntity.java
+++ b/src/main/java/in/tech_camp/protospace_a/entity/UserEntity.java
@@ -11,8 +11,7 @@ public class UserEntity {
   private String email;
   private String password;
   private String profile;
-  private String company;
-  private String role;
+  private String profileImage;
   private List<PrototypeEntity> prototypes;
   private List<CommentEntity> comments;
 }

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -2,7 +2,7 @@ package in.tech_camp.protospace_a.form;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindingResult;
-
+import org.springframework.web.multipart.MultipartFile;
 import in.tech_camp.protospace_a.service.UserService;
 import in.tech_camp.protospace_a.repository.UserRepository;
 import in.tech_camp.protospace_a.validation.ValidationPriority1;
@@ -15,7 +15,8 @@ public class UserForm {
   private String email;
   private String password;
   private String username;
-  private String profile;
+  private String profile;  
+  private MultipartFile profileImage;
   private String passwordConfirmation;
 
   public void validateUserForm(BindingResult result) {

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -15,7 +15,7 @@ public class UserForm {
   private String email;
   private String password;
   private String username;
-  private String profile;  
+  private String profile;
   private MultipartFile profileImage;
   private String passwordConfirmation;
 
@@ -24,6 +24,7 @@ public class UserForm {
     validatePassword(result);
     validateUsername(result);
     validateProfile(result);
+    validateProfileImage(result);
   }
 
   public void validateUsername(BindingResult result) {
@@ -125,9 +126,18 @@ public class UserForm {
       result.rejectValue("profile", "profile", "プロフィールを入力してください");
       return;
     }
-
+    
     if (140 < profile.length()) {
       result.rejectValue("profile", "profile", "プロフィールの文字数は140字以内で入力してください");
+    }
+  }
+  
+  // todo ProfileImageのバリデーション機能作成
+  public void validateProfileImage(BindingResult result) {
+    if (profileImage == null || profileImage.isEmpty()) {
+      // result.rejectValue("profileImage", "profileImage", "プロフィールを入力してください");
+      System.out.println("Profile Image: ");
+      return;
     }
   }
 }

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -132,12 +132,20 @@ public class UserForm {
     }
   }
   
-  // todo ProfileImageのバリデーション機能作成
   public void validateProfileImage(BindingResult result) {
     if (profileImage == null || profileImage.isEmpty()) {
-      // result.rejectValue("profileImage", "profileImage", "プロフィールを入力してください");
-      System.out.println("Profile Image: ");
+      System.out.println("Warning: Profile Image is null");
       return;
     }
+
+    if (256 < profileImage.getOriginalFilename().length()) {
+      result.rejectValue("profileImage", "profileImage", "画像URLは 256 文字以内で入力してください");
+      return;
+    }
+
+    if (10 * 1024 * 1024 < profileImage.getSize()) {
+      result.rejectValue("profileImage", "profileImage", "画像の最大メディア容量は10メガバイトまでです");
+    }
+
   }
 }

--- a/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
+++ b/src/main/java/in/tech_camp/protospace_a/form/UserForm.java
@@ -16,14 +16,6 @@ public class UserForm {
   private String password;
   private String username;
   private String profile;
-
-  @NotBlank(message = "Company can't be blank",
-      groups = ValidationPriority1.class)
-  private String company;
-
-  @NotBlank(message = "Role can't be blank", groups = ValidationPriority1.class)
-  private String role;
-
   private String passwordConfirmation;
 
   public void validateUserForm(BindingResult result) {

--- a/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
@@ -7,7 +7,8 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
-
+import org.apache.ibatis.annotations.Update;
+import in.tech_camp.protospace_a.entity.PrototypeEntity;
 import in.tech_camp.protospace_a.entity.UserEntity;
 
 @Mapper
@@ -30,4 +31,9 @@ public interface UserRepository {
 
     @Select("SELECT * FROM users WHERE id = #{id}")
     UserEntity findByUserId(Integer id);
+
+    
+  @Update("UPDATE users SET username = #{username}, password = #{password}, profile = #{profile}, profile_image = #{profileImage} WHERE id = #{id}")
+  void updateUser(UserEntity user);
+
 }

--- a/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
@@ -12,7 +12,7 @@ import in.tech_camp.protospace_a.entity.UserEntity;
 
 @Mapper
 public interface UserRepository {
-    @Insert("INSERT INTO users (username, email, password, profile, company, role) VALUES (#{username}, #{email}, #{password}, #{profile}, #{company}, #{role})")
+    @Insert("INSERT INTO users (username, email, password, profile) VALUES (#{username}, #{email}, #{password}, #{profile})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(UserEntity user);
 

--- a/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
@@ -12,7 +12,7 @@ import in.tech_camp.protospace_a.entity.UserEntity;
 
 @Mapper
 public interface UserRepository {
-    @Insert("INSERT INTO users (username, email, password, profile) VALUES (#{username}, #{email}, #{password}, #{profile})")
+    @Insert("INSERT INTO users (username, email, password, profile, profileImage) VALUES (#{username}, #{email}, #{password}, #{profile}, #{profileImage})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(UserEntity user);
 

--- a/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
+++ b/src/main/java/in/tech_camp/protospace_a/repository/UserRepository.java
@@ -12,7 +12,7 @@ import in.tech_camp.protospace_a.entity.UserEntity;
 
 @Mapper
 public interface UserRepository {
-    @Insert("INSERT INTO users (username, email, password, profile, profileImage) VALUES (#{username}, #{email}, #{password}, #{profile}, #{profileImage})")
+    @Insert("INSERT INTO users (username, email, password, profile, profile_image) VALUES (#{username}, #{email}, #{password}, #{profile}, #{profileImage})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(UserEntity user);
 

--- a/src/main/resources/db/migration/V10__add_user_image.sql
+++ b/src/main/resources/db/migration/V10__add_user_image.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN profile_image VARCHAR(256);

--- a/src/main/resources/db/migration/V9__delete_company_and_role_column.sql
+++ b/src/main/resources/db/migration/V9__delete_company_and_role_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+DROP COLUMN company,
+DROP COLUMN role;

--- a/src/main/resources/templates/prototypes/new.html
+++ b/src/main/resources/templates/prototypes/new.html
@@ -38,7 +38,7 @@
           </div>
 
           <div class="field">
-            <label clas s="image">プロトタイプの画像</label><br />
+            <label class="image">プロトタイプの画像</label><br />
             <input th:field="*{image}" type="file" name="image" id="image" accept="image/*" />
             <div th:if="${#fields.hasErrors('image')}" th:text="＊ + ${fieldErrors['image']}" class="error_message">
             </div>

--- a/src/main/resources/templates/tmp/signUp.html
+++ b/src/main/resources/templates/tmp/signUp.html
@@ -39,18 +39,6 @@
         <div th:if="${#fields.hasErrors('profile')}" th:errors="*{profile}"></div>
       </div>
 
-      <div>
-        <label>Company:</label>
-        <input th:field="*{company}" required maxlength="50" />
-        <div th:if="${#fields.hasErrors('company')}" th:errors="*{company}"></div>
-      </div>
-
-      <div>
-        <label>Role:</label>
-        <input th:field="*{role}" required maxlength="50" />
-        <div th:if="${#fields.hasErrors('role')}" th:errors="*{role}"></div>
-      </div>
-
       <button type="submit">Register</button>
     </form>
   </body>

--- a/src/main/resources/templates/tmp/users/mypage.html
+++ b/src/main/resources/templates/tmp/users/mypage.html
@@ -12,8 +12,6 @@
     <ul>
       <li><strong>名前：</strong><span th:text="${nickname}"></span></li>
       <li><strong>プロフィール：</strong><span th:text="${profile}"></span></li>
-      <li><strong>所属：</strong><span th:text="${company}"></span></li>
-      <li><strong>役職：</strong><span th:text="${role}"></span></li>
     </ul>
     <hr>
     <h2>このユーザーの投稿プロトタイプ一覧</h2>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
+
+  <head>
+    <meta charset="UTF-8">
+    <link th:href="@{/css/style.css}" rel="stylesheet" type="text/css">
+    <title>ProtoSpace</title>
+  </head>
+
+  <body>
+
+    <div th:insert="~{header :: header}"></div>
+
+    <div class="main_contents">
+      <div class="container_Form">
+        <h2>ユーザープロフィール編集</h2>
+        <form th:method="post" th:action="@{/users/{userId}/update(userId = ${userId})}" th:object="${userForm}"
+          enctype="multipart/form-data" class="new_user">
+
+          <div class="field">
+            <label class="column-title">名前</label><br />
+            <input th:field="*{username}" type="text" id="username" name="username" autofocus="autofocus" />
+            <div th:if="${#fields.hasErrors('username')}" th:text="＊ + ${fieldErrors['username']}"
+              class="error_message">
+            </div>
+          </div>
+
+          <div class="field">
+            <label for="password">パスワード</label><em>(6文字以上)</em><br />
+            <input type="password" id="password" th:field="*{password}" />
+          </div>
+
+          <div class='field'>
+            <div class='field-label'>
+              <label for="password_confirmation">パスワード再入力</label>
+            </div>
+            <div class='field-input'>
+              <input type="password" th:field="*{passwordConfirmation}" id="password_confirmation" autocomplete="off" />
+            </div>
+            <div th:if="${#fields.hasErrors('password')}" th:text="＊ + ${fieldErrors['password']}"
+              class="error_message"></div>
+            <div th:if="${#fields.hasErrors('passwordConfirmation')}"
+              th:text="＊ + ${fieldErrors['passwordConfirmation']}" class="error_message"></div>
+          </div>
+
+          <div class="field">
+            <label class="profile">プロフィール</label><br />
+            <textarea th:field="*{profile}" class="text" id="profile" name="text"></textarea>
+            <div th:if="${#fields.hasErrors('profile')}" th:text="＊ + ${fieldErrors['profile']}" class="error_message">
+            </div>
+          </div>
+
+          <div class="field">
+            <label class="profileImage">プロフィール画像</label><br />
+            <input th:field="*{profileImage}" type="file" name="image" id="profileImage" accept="image/*" />
+            <div th:if="${#fields.hasErrors('profileImage')}" th:text="＊ + ${fieldErrors['profileImage']}"
+              class="error_message">
+            </div>
+          </div>
+
+          <div class="actions">
+            <input type="submit" value="保存する">
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div th:insert="~{footer :: footer}"></div>
+
+  </body>
+
+</html>

--- a/src/main/resources/templates/users/search.html
+++ b/src/main/resources/templates/users/search.html
@@ -31,16 +31,6 @@
               <th class="table_col1">プロフィール</th>
               <td class="table_col2" th:text="${profile}"></td>
             </tr>
-
-            <tr>
-              <th class="table_col1">所属</th>
-              <td class="table_col2" th:text="${company}"></td>
-            </tr>
-
-            <tr>
-              <th class="table_col1">役職</th>
-              <td class="table_col2" th:text="${role}"></td>
-            </tr>
           </tbody>
         </table>
 

--- a/src/main/resources/templates/users/signUp.html
+++ b/src/main/resources/templates/users/signUp.html
@@ -15,7 +15,7 @@
       <div class="container_Form">
         <h2>ユーザー新規登録</h2>
         <div class="form">
-          <form th:action="@{/user}" th:method="post" th:object="${userForm}" , class="new_user">
+          <form th:action="@{/user}" th:method="post" th:object="${userForm}" enctype="multipart/form-data" class="new_user">
 
             <div class="field">
               <label for="email">メールアドレス</label><br />
@@ -56,7 +56,12 @@
               <div th:if="${fieldErrors != null and #maps.containsKey(fieldErrors, 'profile')}"
                 th:text="＊ + ${fieldErrors['profile']}" class="error_message"></div>
             </div>
-
+            <div class="field">
+              <label for="profileImage" class="image">プロフィール画像</label><br />
+              <input th:field="*{profileImage}" type="file" name="profileImage" id="profileImage" accept="image/*" />
+              <!-- <div th:if="${#fields.hasErrors('profileImage')}" th:text="＊ + ${fieldErrors['profileImage']}" class="error_message">
+              </div> -->
+            </div>
             <div class="actions">
               <input type="submit" value="Sign up">
             </div>

--- a/src/main/resources/templates/users/signUp.html
+++ b/src/main/resources/templates/users/signUp.html
@@ -57,16 +57,6 @@
                 th:text="＊ + ${fieldErrors['profile']}" class="error_message"></div>
             </div>
 
-            <div class="field">
-              <label for="company">所属</label><br />
-              <input type="text" id="company" th:field="*{company}" autofocus="autofocus" />
-            </div>
-
-            <div class="field">
-              <label for="role">役職 </label><br />
-              <input type="text" id="role" th:field="*{role}" autofocus="autofocus" />
-            </div>
-
             <div class="actions">
               <input type="submit" value="Sign up">
             </div>

--- a/src/main/resources/templates/users/userInfo.html
+++ b/src/main/resources/templates/users/userInfo.html
@@ -33,16 +33,6 @@
               <th class="table_col1">プロフィール</th>
               <td class="table_col2" th:text="${profile}"></td>
             </tr>
-
-            <tr>
-              <th class="table_col1">所属</th>
-              <td class="table_col2" th:text="${company}"></td>
-            </tr>
-
-            <tr>
-              <th class="table_col1">役職</th>
-              <td class="table_col2" th:text="${role}"></td>
-            </tr>
           </tbody>
         </table>
 

--- a/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 
@@ -243,8 +244,61 @@ public class UserFormUnitTest {
         result = new BeanPropertyBindingResult(form, "userForm");
         form.validateUserForm(result);
         assertTrue(result.hasFieldErrors("profile"));
-        assertEquals("プロフィールの文字数は140字以内で入力してください", result.getFieldError("profile").getDefaultMessage());
+        assertEquals("プロフィールの文字数は140字以内で入力してください",
+                result.getFieldError("profile").getDefaultMessage());
     }
+    
+    
+    @Test
+    public void profileImageがnullの場合エラー() {
+        form.setProfileImage(null);
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("profileImage"));
+    }
+    
+    @Test
+    public void profileImageが空ファイルの場合エラー() {
+        form.setProfileImage(new MockMultipartFile("profileImage", new byte[0]));
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("profileImage"));
+    }
+
+    @Test
+    public void profileImageのurlの文字数が256文字の場合成功() {
+        form.setProfileImage(new MockMultipartFile("profileImage", "a".repeat(252) + ".png", "profileImage/png", "dummy profileImage content".getBytes()));
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("profileImage"));
+    }
+
+    @Test
+    public void profileImageのurlの文字数が257文字の場合エラー() {
+        form.setProfileImage(new MockMultipartFile("profileImage", "a".repeat(253) + ".png", "profileImage/png", "dummy profileImage content".getBytes()));
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("profileImage"));
+        assertEquals("画像URLは 256 文字以内で入力してください", result.getFieldError("profileImage").getDefaultMessage());
+    }
+    
+    @Test
+    public void profileImageのファイルが10MBの場合成功() {
+        form.setProfileImage(new MockMultipartFile("profileImage", new byte[10 * 1024 * 1024]));
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertFalse(result.hasFieldErrors("profileImage"));
+    }
+
+    @Test
+    public void profileImageのファイルが11MBの場合エラー() {
+        form.setProfileImage(new MockMultipartFile("profileImage", new byte[11 * 1024 * 1024]));
+        BindingResult result = new BeanPropertyBindingResult(form, "prototypeForm");
+        form.validateUserForm(result);
+        assertTrue(result.hasFieldErrors("profileImage"));
+        assertEquals("画像の最大メディア容量は10メガバイトまでです", result.getFieldError("profileImage").getDefaultMessage());
+    }
+
 
     private UserForm createValidUserForm() {
         UserForm form = new UserForm();

--- a/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
+++ b/src/test/java/in/tech_camp/protospace_a/form/UserFormUnitTest.java
@@ -246,24 +246,6 @@ public class UserFormUnitTest {
         assertEquals("プロフィールの文字数は140字以内で入力してください", result.getFieldError("profile").getDefaultMessage());
     }
 
-    @Test
-    public void companyが空ならバリデーションエラーになる() {
-        form.setCompany("");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Company can't be blank", violations.iterator().next().getMessage());
-    }
-
-    @Test
-    public void roleが空ならバリデーションエラーになる() {
-        form.setRole("");
-
-        Set<ConstraintViolation<UserForm>> violations = validator.validate(form, ValidationPriority1.class);
-        assertEquals(1, violations.size());
-        assertEquals("Role can't be blank", violations.iterator().next().getMessage());
-    }
-
     private UserForm createValidUserForm() {
         UserForm form = new UserForm();
         form.setEmail("test@example.com");
@@ -271,8 +253,6 @@ public class UserFormUnitTest {
         form.setPasswordConfirmation("1aA".repeat(6));
         form.setUsername("TestUser");
         form.setProfile("テストプロフィール");
-        form.setCompany("TechCamp");
-        form.setRole("エンジニア");
         return form;
     }
 }


### PR DESCRIPTION
# したこと
ユーザー編集機能作成
- ユーザー編集画面作成
- ユーザー名、プロフィール、パスワード、確認用のパスワード、画像を更新（画像は任意）

# してないこと
- テスト作成
- ユーザープロフィールの編集ボタン（アイコン作成）
- ログインユーザーが自分のプロフィールを編集機能を実装したのですが、現在、URL経由でほかのユーザーのプロフィールを編集できるように修正
- 万が一ユーザーがパスワードを忘れた場合の新しくパスワードを設定する機能
- こんちちわの表示をユーザー名に変更（UI変更時に削除するため）

# 挙動確認
### 編集前
![Screenshot 2025-07-02 104233](https://github.com/user-attachments/assets/b24a1093-1125-48a6-8466-012c7a20430d)

### 編集画面
![Screenshot 2025-07-02 104307](https://github.com/user-attachments/assets/3fe780ef-c068-4f18-ada0-eb8231df82e6)

### 編集後
![Screenshot 2025-07-02 104319](https://github.com/user-attachments/assets/8de80bdf-4667-4fed-ae35-94e6c2f10df5)

`*URL経由でほかのユーザーの編集画面に遷移しようとしたときは画面にエラーメッセージは表示せずに、トップページに遷移するようにしています。`
![Screenshot 2025-07-02 103938](https://github.com/user-attachments/assets/bf09f9f2-2571-4730-a045-9d5cdf6da693)

